### PR TITLE
Fix C# code example for Object._get_property_list

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -136,7 +136,7 @@
 				        }
 				    }
 
-				    private List&lt;int&gt; _numbers = new();
+				    private Godot.Collections.Array&lt;int&gt; _numbers = new();
 
 				    public override Godot.Collections.Array&lt;Godot.Collections.Dictionary&gt; _GetPropertyList()
 				    {
@@ -173,7 +173,7 @@
 				        if (propertyName.StartsWith("number_"))
 				        {
 				            int index = int.Parse(propertyName.Substring("number_".Length));
-				            numbers[index] = value.As&lt;int&gt;();
+				            _numbers[index] = value.As&lt;int&gt;();
 				            return true;
 				        }
 				        return false;


### PR DESCRIPTION
There were two small errors in this code example that kept it from working when copied to a new node locally. These are the fixes I used locally to test the example.
